### PR TITLE
Support for logical delete

### DIFF
--- a/src/AutoMapper.Collection.Tests/MapCollectionWithEquality.cs
+++ b/src/AutoMapper.Collection.Tests/MapCollectionWithEquality.cs
@@ -15,7 +15,7 @@ namespace AutoMapper.Collection
             {
                 x.AddProfile<CollectionProfile>();
                 x.CreateMap<ThingDto, Thing>().EqualityComparision((dto, entity) => dto.ID == entity.ID);
-                x.CreateMap<AnotherThingDto, AnotherThing>().EqualityComparision((dto, entity) => dto.ID == entity.ID, (entity,isdeleted) => entity.IsDeleted = true);
+                x.CreateMap<AnotherThingDto, AnotherThing>().EqualityComparision((dto, entity) => dto.ID == entity.ID, entity => entity.IsDeleted = true);
             });
         }
 

--- a/src/AutoMapper.Collection.Tests/MapCollectionWithEquality.cs
+++ b/src/AutoMapper.Collection.Tests/MapCollectionWithEquality.cs
@@ -15,6 +15,7 @@ namespace AutoMapper.Collection
             {
                 x.AddProfile<CollectionProfile>();
                 x.CreateMap<ThingDto, Thing>().EqualityComparision((dto, entity) => dto.ID == entity.ID);
+                x.CreateMap<AnotherThingDto, AnotherThing>().EqualityComparision((dto, entity) => dto.ID == entity.ID, (entity,isdeleted) => entity.IsDeleted = true);
             });
         }
 
@@ -63,6 +64,26 @@ namespace AutoMapper.Collection
             Mapper.Map<List<Thing>>(dtos).Should().HaveSameCount(dtos);
         }
 
+        public void Should_Update_IsDeleted_From_Removed_Item()
+        {
+            var dtos = new List<AnotherThingDto>
+            {
+                new AnotherThingDto { ID = 1, Title = "test0" },
+                new AnotherThingDto { ID = 2, Title = "test2" }
+            };
+
+            var items = new List<AnotherThing>
+            {
+                new AnotherThing { ID = 1, Title = "test1", IsDeleted = false },
+                new AnotherThing { ID = 3, Title = "test3", IsDeleted = false },
+            };
+
+            Mapper.Map(dtos, items).Should().HaveElementAt(0, items.First()).And.HaveCount(3);
+            items[0].IsDeleted.Should().BeFalse();
+            items[1].IsDeleted.Should().BeTrue();
+            items[2].IsDeleted.Should().BeFalse();
+        }
+
         public class Thing
         {
             public int ID { get; set; }
@@ -71,6 +92,20 @@ namespace AutoMapper.Collection
         }
 
         public class ThingDto
+        {
+            public int ID { get; set; }
+            public string Title { get; set; }
+        }
+
+        public class AnotherThing
+        {
+            public int ID { get; set; }
+            public string Title { get; set; }
+            public bool IsDeleted { get; set; }
+            public override string ToString() { return Title; }
+        }
+
+        public class AnotherThingDto
         {
             public int ID { get; set; }
             public string Title { get; set; }

--- a/src/AutoMapper.Collection/CollectionProfile.cs
+++ b/src/AutoMapper.Collection/CollectionProfile.cs
@@ -9,6 +9,7 @@
         protected override void Configure()
         {
             InsertBefore<ReadOnlyCollectionMapper>(new ObjectToEquivalencyExpressionByEquivalencyExistingMapper());
+            InsertBefore<ReadOnlyCollectionMapper>(new EquivlentExpressionSoftDeleteCollectionMapper());
             InsertBefore<ReadOnlyCollectionMapper>(new EquivlentExpressionAddRemoveCollectionMapper());
         }
 

--- a/src/AutoMapper.Collection/Equivilency Expression/EquivilentExpression.cs
+++ b/src/AutoMapper.Collection/Equivilency Expression/EquivilentExpression.cs
@@ -20,17 +20,29 @@ namespace AutoMapper.EquivilencyExpression
         where TDestination : class
     {
         private readonly Expression<Func<TSource, TDestination, bool>> _equivilentExpression;
-        private readonly Func<TSource, TDestination, bool> _equivilentFunc; 
+        private readonly Func<TSource, TDestination, bool> _equivilentFunc;
+        private readonly Action<TDestination, bool> _softDeleteAction;
 
-        public EquivilentExpression(Expression<Func<TSource,TDestination,bool>> equivilentExpression)
+        public EquivilentExpression(Expression<Func<TSource,TDestination,bool>> equivilentExpression, Action<TDestination, bool> softDeleteAction = null)
         {
             _equivilentExpression = equivilentExpression;
             _equivilentFunc = _equivilentExpression.Compile();
+            _softDeleteAction = softDeleteAction;
         }
 
         public bool IsEquivlent(TSource source, TDestination destination)
         {
             return _equivilentFunc(source, destination);
+        }
+
+        public bool IsSoftDelete()
+        {
+            return _softDeleteAction != null;
+        }
+
+        public void SetSoftDeleteValue(TDestination detination, bool value)
+        {
+            _softDeleteAction(detination, value);
         }
 
         public Expression<Func<TDestination, bool>> ToSingleSourceExpression(TSource source)

--- a/src/AutoMapper.Collection/Equivilency Expression/EquivilentExpression.cs
+++ b/src/AutoMapper.Collection/Equivilency Expression/EquivilentExpression.cs
@@ -21,9 +21,37 @@ namespace AutoMapper.EquivilencyExpression
     {
         private readonly Expression<Func<TSource, TDestination, bool>> _equivilentExpression;
         private readonly Func<TSource, TDestination, bool> _equivilentFunc;
-        private readonly Action<TDestination, bool> _softDeleteAction;
 
-        public EquivilentExpression(Expression<Func<TSource,TDestination,bool>> equivilentExpression, Action<TDestination, bool> softDeleteAction = null)
+        public EquivilentExpression(Expression<Func<TSource,TDestination,bool>> equivilentExpression)
+        {
+            _equivilentExpression = equivilentExpression;
+            _equivilentFunc = _equivilentExpression.Compile();
+        }
+
+        public bool IsEquivlent(TSource source, TDestination destination)
+        {
+            return _equivilentFunc(source, destination);
+        }
+
+        public Expression<Func<TDestination, bool>> ToSingleSourceExpression(TSource source)
+        {
+            if (source == null)
+                throw new Exception("Invalid somehow");
+
+            var expression = new ParametersToConstantVisitor<TSource>(source).Visit(_equivilentExpression) as LambdaExpression;
+            return Expression.Lambda<Func<TDestination, bool>>(expression.Body, _equivilentExpression.Parameters[1]);
+        }
+    }
+
+    internal class EquivilentExpressionSoftDelete<TSource, TDestination> : IEquivilentSoftDeleteExpression<TSource, TDestination>
+       where TSource : class
+       where TDestination : class
+    {
+        private readonly Expression<Func<TSource, TDestination, bool>> _equivilentExpression;
+        private readonly Func<TSource, TDestination, bool> _equivilentFunc;
+        private readonly Action<TDestination> _softDeleteAction;
+
+        public EquivilentExpressionSoftDelete(Expression<Func<TSource, TDestination, bool>> equivilentExpression, Action<TDestination> softDeleteAction = null)
         {
             _equivilentExpression = equivilentExpression;
             _equivilentFunc = _equivilentExpression.Compile();
@@ -35,14 +63,9 @@ namespace AutoMapper.EquivilencyExpression
             return _equivilentFunc(source, destination);
         }
 
-        public bool IsSoftDelete()
+        public void SetSoftDeleteValue(TDestination detination)
         {
-            return _softDeleteAction != null;
-        }
-
-        public void SetSoftDeleteValue(TDestination detination, bool value)
-        {
-            _softDeleteAction(detination, value);
+            _softDeleteAction(detination);
         }
 
         public Expression<Func<TDestination, bool>> ToSingleSourceExpression(TSource source)

--- a/src/AutoMapper.Collection/Equivilency Expression/EquivilentExpressions.cs
+++ b/src/AutoMapper.Collection/Equivilency Expression/EquivilentExpressions.cs
@@ -36,5 +36,64 @@ namespace AutoMapper.EquivilencyExpression
             UserDefinedEquivilentExpressions.AddEquivilencyExpression(equivilentExpression);
             return mappingExpression;
         }
+
+
+        /// <summary>
+        /// Make Comparison between <typeparamref name="TSource"/> and <typeparamref name="TDestination"/>
+        /// </summary>
+        /// <typeparam name="TSource">Compared type</typeparam>
+        /// <typeparam name="TDestination">Type being compared to</typeparam>
+        /// <param name="mappingExpression">Base Mapping Expression</param>
+        /// <param name="equivilentExpression">Equivilent Expression between <typeparamref name="TSource"/> and <typeparamref name="TDestination"/></param>
+        /// <param name="softDeletePropertyExpression">Property that will be set to True when a element has been deleted</param>
+        /// <returns></returns>
+        public static IMappingExpression<TSource, TDestination> EqualityComparision<TSource, TDestination>(this IMappingExpression<TSource, TDestination> mappingExpression, Expression<Func<TSource, TDestination, bool>> equivilentExpression,
+            Expression<Func<TDestination, bool>> softDeletePropertyExpression)
+            where TSource : class
+            where TDestination : class
+        {
+            UserDefinedEquivilentExpressions.AddEquivilencyExpression(equivilentExpression, softDeletePropertyExpression.GetSetter());
+            return mappingExpression;
+        }
+
+        /// <summary>
+        /// Make Comparison between <typeparamref name="TSource"/> and <typeparamref name="TDestination"/>
+        /// </summary>
+        /// <typeparam name="TSource">Compared type</typeparam>
+        /// <typeparam name="TDestination">Type being compared to</typeparam>
+        /// <param name="mappingExpression">Base Mapping Expression</param>
+        /// <param name="equivilentExpression">Equivilent Expression between <typeparamref name="TSource"/> and <typeparamref name="TDestination"/></param>
+        /// <param name="softDeleteAction">Action that will be called when a element has been deleted</param>
+        /// <returns></returns>
+        public static IMappingExpression<TSource, TDestination> EqualityComparision<TSource, TDestination>(this IMappingExpression<TSource, TDestination> mappingExpression, Expression<Func<TSource, TDestination, bool>> equivilentExpression,
+           Action<TDestination,bool> softDeleteAction)
+           where TSource : class
+           where TDestination : class
+        {
+            UserDefinedEquivilentExpressions.AddEquivilencyExpression(equivilentExpression, softDeleteAction);
+            return mappingExpression;
+        }
+
+        /// <summary>
+        /// Convert a lambda expression for a getter into a setter
+        /// </summary>
+        private static Action<T, TProperty> GetSetter<T, TProperty>(this Expression<Func<T, TProperty>> expression)
+        {
+            var memberExpression = (MemberExpression)expression.Body;
+            var property = (System.Reflection.PropertyInfo)memberExpression.Member;
+            var setMethod = property.SetMethod;
+
+            var parameterT = Expression.Parameter(typeof(T), "x");
+            var parameterTProperty = Expression.Parameter(typeof(TProperty), "y");
+
+            var newExpression =
+                Expression.Lambda<Action<T, TProperty>>(
+                    Expression.Call(parameterT, setMethod, parameterTProperty),
+                    parameterT,
+                    parameterTProperty
+                );
+
+            return newExpression.Compile();
+        }
     }
 }

--- a/src/AutoMapper.Collection/Equivilency Expression/EquivilentExpressions.cs
+++ b/src/AutoMapper.Collection/Equivilency Expression/EquivilentExpressions.cs
@@ -37,25 +37,6 @@ namespace AutoMapper.EquivilencyExpression
             return mappingExpression;
         }
 
-
-        /// <summary>
-        /// Make Comparison between <typeparamref name="TSource"/> and <typeparamref name="TDestination"/>
-        /// </summary>
-        /// <typeparam name="TSource">Compared type</typeparam>
-        /// <typeparam name="TDestination">Type being compared to</typeparam>
-        /// <param name="mappingExpression">Base Mapping Expression</param>
-        /// <param name="equivilentExpression">Equivilent Expression between <typeparamref name="TSource"/> and <typeparamref name="TDestination"/></param>
-        /// <param name="softDeletePropertyExpression">Property that will be set to True when a element has been deleted</param>
-        /// <returns></returns>
-        public static IMappingExpression<TSource, TDestination> EqualityComparision<TSource, TDestination>(this IMappingExpression<TSource, TDestination> mappingExpression, Expression<Func<TSource, TDestination, bool>> equivilentExpression,
-            Expression<Func<TDestination, bool>> softDeletePropertyExpression)
-            where TSource : class
-            where TDestination : class
-        {
-            UserDefinedEquivilentExpressions.AddEquivilencyExpression(equivilentExpression, softDeletePropertyExpression.GetSetter());
-            return mappingExpression;
-        }
-
         /// <summary>
         /// Make Comparison between <typeparamref name="TSource"/> and <typeparamref name="TDestination"/>
         /// </summary>
@@ -66,34 +47,12 @@ namespace AutoMapper.EquivilencyExpression
         /// <param name="softDeleteAction">Action that will be called when a element has been deleted</param>
         /// <returns></returns>
         public static IMappingExpression<TSource, TDestination> EqualityComparision<TSource, TDestination>(this IMappingExpression<TSource, TDestination> mappingExpression, Expression<Func<TSource, TDestination, bool>> equivilentExpression,
-           Action<TDestination,bool> softDeleteAction)
+           Action<TDestination> softDeleteAction)
            where TSource : class
            where TDestination : class
         {
             UserDefinedEquivilentExpressions.AddEquivilencyExpression(equivilentExpression, softDeleteAction);
             return mappingExpression;
-        }
-
-        /// <summary>
-        /// Convert a lambda expression for a getter into a setter
-        /// </summary>
-        private static Action<T, TProperty> GetSetter<T, TProperty>(this Expression<Func<T, TProperty>> expression)
-        {
-            var memberExpression = (MemberExpression)expression.Body;
-            var property = (System.Reflection.PropertyInfo)memberExpression.Member;
-            var setMethod = property.SetMethod;
-
-            var parameterT = Expression.Parameter(typeof(T), "x");
-            var parameterTProperty = Expression.Parameter(typeof(TProperty), "y");
-
-            var newExpression =
-                Expression.Lambda<Action<T, TProperty>>(
-                    Expression.Call(parameterT, setMethod, parameterTProperty),
-                    parameterT,
-                    parameterTProperty
-                );
-
-            return newExpression.Compile();
         }
     }
 }

--- a/src/AutoMapper.Collection/Equivilency Expression/IEquivilentExpression.cs
+++ b/src/AutoMapper.Collection/Equivilency Expression/IEquivilentExpression.cs
@@ -11,5 +11,7 @@ namespace AutoMapper.EquivilencyExpression
     {
         bool IsEquivlent(TSource source, TDestination destination);
         Expression<Func<TDestination, bool>> ToSingleSourceExpression(TSource destination);
+        bool IsSoftDelete();
+        void SetSoftDeleteValue(TDestination detination, bool value);
     }
 }

--- a/src/AutoMapper.Collection/Equivilency Expression/IEquivilentExpression.cs
+++ b/src/AutoMapper.Collection/Equivilency Expression/IEquivilentExpression.cs
@@ -7,11 +7,17 @@ namespace AutoMapper.EquivilencyExpression
     {
         
     }
+
+    public interface IEquivilentSoftDeleteExpression { }
+
     public interface IEquivilentExpression<TSource, TDestination> : IEquivilentExpression
     {
         bool IsEquivlent(TSource source, TDestination destination);
         Expression<Func<TDestination, bool>> ToSingleSourceExpression(TSource destination);
-        bool IsSoftDelete();
-        void SetSoftDeleteValue(TDestination detination, bool value);
+    }
+
+    public interface IEquivilentSoftDeleteExpression<TSource, TDestination> : IEquivilentExpression<TSource, TDestination>, IEquivilentSoftDeleteExpression
+    {
+        void SetSoftDeleteValue(TDestination detination);
     }
 }

--- a/src/AutoMapper.Collection/Equivilency Expression/UserDefinedEquivilentExpressions.cs
+++ b/src/AutoMapper.Collection/Equivilency Expression/UserDefinedEquivilentExpressions.cs
@@ -38,12 +38,12 @@ namespace AutoMapper.EquivilencyExpression
             destinationDictionary.AddOrUpdate(typeof(TSource), new EquivilentExpression<TSource, TDestination>(equivilentExpression), (type, old) => new EquivilentExpression<TSource, TDestination>(equivilentExpression));
         }
 
-        internal void AddEquivilencyExpression<TSource, TDestination>(Expression<Func<TSource, TDestination, bool>> equivilentExpression, Action<TDestination, bool> softDeleteAction)
+        internal void AddEquivilencyExpression<TSource, TDestination>(Expression<Func<TSource, TDestination, bool>> equivilentExpression, Action<TDestination> softDeleteAction)
             where TSource : class
             where TDestination : class
         {
             var destinationDictionary = _equivilentExpressionDictionary.GetOrAdd(typeof(TDestination), t => new ConcurrentDictionary<Type, IEquivilentExpression>());
-            destinationDictionary.AddOrUpdate(typeof(TSource), new EquivilentExpression<TSource, TDestination>(equivilentExpression, softDeleteAction), (type, old) => new EquivilentExpression<TSource, TDestination>(equivilentExpression, softDeleteAction));
+            destinationDictionary.AddOrUpdate(typeof(TSource), new EquivilentExpressionSoftDelete<TSource, TDestination>(equivilentExpression, softDeleteAction), (type, old) => new EquivilentExpressionSoftDelete<TSource, TDestination>(equivilentExpression, softDeleteAction));
         }
     }
 }

--- a/src/AutoMapper.Collection/Equivilency Expression/UserDefinedEquivilentExpressions.cs
+++ b/src/AutoMapper.Collection/Equivilency Expression/UserDefinedEquivilentExpressions.cs
@@ -37,5 +37,13 @@ namespace AutoMapper.EquivilencyExpression
             var destinationDictionary = _equivilentExpressionDictionary.GetOrAdd(typeof(TDestination), t => new ConcurrentDictionary<Type, IEquivilentExpression>());
             destinationDictionary.AddOrUpdate(typeof(TSource), new EquivilentExpression<TSource, TDestination>(equivilentExpression), (type, old) => new EquivilentExpression<TSource, TDestination>(equivilentExpression));
         }
+
+        internal void AddEquivilencyExpression<TSource, TDestination>(Expression<Func<TSource, TDestination, bool>> equivilentExpression, Action<TDestination, bool> softDeleteAction)
+            where TSource : class
+            where TDestination : class
+        {
+            var destinationDictionary = _equivilentExpressionDictionary.GetOrAdd(typeof(TDestination), t => new ConcurrentDictionary<Type, IEquivilentExpression>());
+            destinationDictionary.AddOrUpdate(typeof(TSource), new EquivilentExpression<TSource, TDestination>(equivilentExpression, softDeleteAction), (type, old) => new EquivilentExpression<TSource, TDestination>(equivilentExpression, softDeleteAction));
+        }
     }
 }

--- a/src/AutoMapper.Collection/Mappers/EquivlentExpressionAddRemoveCollectionMapper.cs
+++ b/src/AutoMapper.Collection/Mappers/EquivlentExpressionAddRemoveCollectionMapper.cs
@@ -22,7 +22,16 @@ namespace AutoMapper.Mappers
             var compareSourceToDestination = source.ToDictionary(s => s, s => destination.FirstOrDefault(d => equivilencyExpression.IsEquivlent(s, d)));
 
             foreach (var removedItem in destination.Except(compareSourceToDestination.Values).ToList())
-                destination.Remove(removedItem);
+            {
+                if (equivilencyExpression.IsSoftDelete())
+                {
+                    equivilencyExpression.SetSoftDeleteValue(removedItem, true);
+                }
+                else
+                {
+                    destination.Remove(removedItem);
+                }
+            }
 
             foreach (var keypair in compareSourceToDestination)
             {


### PR DESCRIPTION
I don´t know how interesting it is for you this PR. It add a mapper that allows action for soft delete when configuring the EqualityComparision.
Sometimes we don´t want to delete the registry from the database, only deactivate it.
With this mapper, the registry it´s not removed from the collection.
There is a unit test case showing how to use it.

```csharp
x.CreateMap<Dto, Entity>()
  .EqualityComparision((dto, entity) => dto.Id == entity.Id, entity => entity.IsDeleted = true)
```