### PR TITLE
Speed up large lists

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -37,7 +37,8 @@ task compile -depends clean {
 	$buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
 	
 	echo "build: Tag is $tag"
-	echo "build: Package version suffix is $version"
+	echo "build: Package version suffix is $suffix"
+	echo "build: Build version suffix is $buildSuffix" 
 
     exec { .\.nuget\NuGet.exe restore $base_dir\AutoMapper.Collection.sln }
 

--- a/src/AutoMapper.Collection-Signed/AutoMapper.Collection-Signed.csproj
+++ b/src/AutoMapper.Collection-Signed/AutoMapper.Collection-Signed.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Collection Add/Remove/Update support for AutoMapper. AutoMapper.Collection adds EqualityComparison Expressions for TypeMaps to determine if Source and Destination type are equivalent to each other when mapping collections.</Description>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <Authors>Tyler Carlson</Authors>
     <TargetFrameworks>net45;netstandard1.1;netstandard1.3</TargetFrameworks>
     <AssemblyName>AutoMapper.Collection-Signed</AssemblyName>

--- a/src/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
+++ b/src/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Collection updating support for EntityFramework with AutoMapper. Extends DBSet&lt;T&gt; with Persist&lt;TDto&gt;().InsertUpdate(dto) and Persist&lt;TDto&gt;().Delete(dto).  Will find the matching object and will Insert/Update/Delete.</Description>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <Authors>Tyler Carlson</Authors>
     <TargetFramework>net45</TargetFramework>
     <AssemblyName>AutoMapper.Collection.EntityFramework</AssemblyName>
@@ -10,7 +10,6 @@
     <PackageIconUrl>https://s3.amazonaws.com/automapper/icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/AutoMapper/Automapper.Collection</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/AutoMapper/AutoMapper.Collection/blob/master/LICENSE.txt</PackageLicenseUrl>
-    <Version>3.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AutoMapper.Collection.LinqToSQL/AutoMapper.Collection.LinqToSQL.csproj
+++ b/src/AutoMapper.Collection.LinqToSQL/AutoMapper.Collection.LinqToSQL.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Collection updating support for LinqToSQL with AutoMapper. Extends Table&lt;T&gt; with Persist&lt;TDto&gt;().InsertUpdate(dto) and Persist&lt;TDto&gt;().Delete(dto).  Will find the matching object and will Insert/Update/Delete.</Description>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <Authors>Tyler Carlson</Authors>
     <TargetFramework>net45</TargetFramework>
     <AssemblyName>AutoMapper.Collection.LinqToSQL</AssemblyName>
@@ -10,7 +10,6 @@
     <PackageIconUrl>https://s3.amazonaws.com/automapper/icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/AutoMapper/Automapper.Collection</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/AutoMapper/AutoMapper.Collection/blob/master/LICENSE.txt</PackageLicenseUrl>
-    <Version>3.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AutoMapper.Collection.Tests/MapCollectionWithEquality.cs
+++ b/src/AutoMapper.Collection.Tests/MapCollectionWithEquality.cs
@@ -50,6 +50,15 @@ namespace AutoMapper.Collection
             Mapper.Map(dtos, items.ToList()).Should().HaveElementAt(0, items.First());
         }
 
+        public void Should_Be_Fast_With_Large_Lists()
+        {
+            var dtos = new object[100000].Select((_, i) => new ThingDto {ID = i}).ToList();
+
+            var items = new object[100000].Select((_, i) => new Thing { ID = i }).ToList();
+
+            Mapper.Map(dtos, items.ToList()).Should().HaveElementAt(0, items.First());
+        }
+
         public void Should_Work_With_Null_Destination()
         {
             var dtos = new List<ThingDto>

--- a/src/AutoMapper.Collection/AutoMapper.Collection.csproj
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Collection Add/Remove/Update support for AutoMapper. AutoMapper.Collection adds EqualityComparison Expressions for TypeMaps to determine if Source and Destination type are equivalent to each other when mapping collections.</Description>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <Authors>Tyler Carlson</Authors>
     <TargetFrameworks>net45;netstandard1.1;netstandard1.3</TargetFrameworks>
     <AssemblyName>AutoMapper.Collection</AssemblyName>
@@ -11,7 +11,6 @@
     <PackageProjectUrl>https://github.com/AutoMapper/Automapper.Collection</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/AutoMapper/AutoMapper.Collection/blob/master/LICENSE.txt</PackageLicenseUrl>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.1' ">$(PackageTargetFallback);portable-net45+win8+dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <Version>3.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
+++ b/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
@@ -21,7 +21,13 @@ namespace AutoMapper.Mappers
             if (source == null || destination == null)
                 return destination;
 
-            var compareSourceToDestination = source.ToDictionary(s => s, s => destination.FirstOrDefault(d => EquivalencyExpression.IsEquivalent(s, d)));
+            var destList = destination.ToList();
+            var compareSourceToDestination = source.ToDictionary(s => s, s =>
+            {
+                var match = destList.FirstOrDefault(d => EquivalencyExpression.IsEquivalent(s, d));
+                destList.Remove(match);
+                return match;
+            });
 
             foreach (var removedItem in destination.Except(compareSourceToDestination.Values).ToList())
                 destination.Remove(removedItem);


### PR DESCRIPTION
Make a new list for destination and remove items as you find matches.  That way don't have to re-iterate through them in large collections.

Execution more around O vs (O^2)/2 assuming ordered the same way.