### PR TITLE
Pass context to mapper to make PreserveReferences work

### DIFF
--- a/src/AutoMapper.Collection.Tests/MapCollectionWithEquality.cs
+++ b/src/AutoMapper.Collection.Tests/MapCollectionWithEquality.cs
@@ -84,6 +84,33 @@ namespace AutoMapper.Collection
             Mapper.Map(dtos, items.ToList()).Should().NotContain(items.First());
         }
 
+        public void Parent_Should_Be_Same_As_Root_Object()
+        {
+            var mapper = new MapperConfiguration(
+                cfg =>
+                {
+                    cfg.AddCollectionMappers();
+                    cfg.CreateMap<ThingWithCollection, ThingWithCollection>()
+                       .PreserveReferences();
+                    cfg.CreateMap<ThingCollectionItem, ThingCollectionItem>()
+                       .EqualityComparison((src, dst) => src.ID == dst.ID)
+                       .PreserveReferences();
+                })
+                .CreateMapper();
+
+            var root = new ThingWithCollection()
+            {
+                Children = new List<ThingCollectionItem>()
+            };
+            root.Children.Add(new ThingCollectionItem() { ID = 1, Parent = root });
+
+            var target = new ThingWithCollection() { Children = new List<ThingCollectionItem>() };
+            mapper.Map(root, target).Should().Be(target);
+
+            target.Children.Count.Should().Be(1);
+            target.Children.Single().Parent.Should().Be(target);
+        }
+
         public class Thing
         {
             public int ID { get; set; }
@@ -95,6 +122,17 @@ namespace AutoMapper.Collection
         {
             public int ID { get; set; }
             public string Title { get; set; }
+        }
+
+        public class ThingWithCollection
+        {
+            public ICollection<ThingCollectionItem> Children { get; set; }
+        }
+
+        public class ThingCollectionItem
+        {
+            public int ID { get; set; }
+            public ThingWithCollection Parent { get; set; }
         }
     }
 }

--- a/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
+++ b/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
@@ -29,20 +29,12 @@ namespace AutoMapper.Mappers
             foreach (var keypair in compareSourceToDestination)
             {
                 if (keypair.Value == null)
-                    destination.Add(context.Mapper.Map<TDestinationItem>(keypair.Key, opts => CopyOptions(context.Options, opts)));
+                    destination.Add((TDestinationItem) context.Mapper.Map(keypair.Key, null, typeof(TSourceItem), typeof(TDestinationItem), context));
                 else
-                    context.Mapper.Map(keypair.Key, keypair.Value, opts => CopyOptions(context.Options, opts));
+                    context.Mapper.Map(keypair.Key, keypair.Value, context);
             }
 
             return destination;
-        }
-
-        private static void CopyOptions(IMappingOperationOptions source, IMappingOperationOptions dest)
-        {
-            foreach (var item in source.Items)
-            {
-                dest.Items[item.Key] = item.Value;
-            }
         }
 
         private static readonly MethodInfo MapMethodInfo = typeof(EquivalentExpressionAddRemoveCollectionMapper).GetRuntimeMethods().First(_ => _.IsStatic);


### PR DESCRIPTION
When the context isn't passed to the mapper, a new one would be created. This would result in `PreserveReferences()` not working as expected (multiple instances for same source object).