### PR TITLE
Update of build script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ deploy:
   server: https://www.myget.org/F/automapperdev/api/v2/package
   api_key:
     secure: zKeQZmIv9PaozHQRJmrlRHN+jMCI64Uvzmb/vwePdXFR5CUNEHalnZdOCg0vrh8t
+  skip_symbols: true
   on:
     branch: master
 - provider: NuGet

--- a/build.ps1
+++ b/build.ps1
@@ -36,6 +36,9 @@ task compile -depends clean {
 	$commitHash = $(git rev-parse --short HEAD)
 	$buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
 	
+	$buildParam = @{ $true = ""; $false = "--version-suffix=$buildSuffix"}[$tag -ne $NULL -and $revision -ne "local"]
+	$packageParam = @{ $true = ""; $false = "--version-suffix=$suffix"}[$tag -ne $NULL -and $revision -ne "local"]
+
 	echo "build: Tag is $tag"
 	echo "build: Package version suffix is $suffix"
 	echo "build: Build version suffix is $buildSuffix" 
@@ -46,13 +49,13 @@ task compile -depends clean {
 	# restore all project references (creating project.assets.json for each project)
 	exec { dotnet restore $base_dir\AutoMapper.Collection.sln }
 
-	exec { dotnet build $base_dir\AutoMapper.Collection.sln -c $config --version-suffix="$buildSuffix" /nologo }
+	exec { dotnet build $base_dir\AutoMapper.Collection.sln -c $config $buildParam /nologo }
 
-	exec { dotnet pack $source_dir\AutoMapper.Collection -c $config --include-symbols --no-build --output $artifacts_dir --version-suffix="$suffix" /nologo}
+	exec { dotnet pack $source_dir\AutoMapper.Collection -c $config --include-symbols --no-build --output $artifacts_dir $packageParam /nologo}
 
-	exec { dotnet pack $source_dir\AutoMapper.Collection.EntityFramework -c $config --include-symbols --no-build --output $artifacts_dir --version-suffix="$suffix" /nologo}
+	exec { dotnet pack $source_dir\AutoMapper.Collection.EntityFramework -c $config --include-symbols --no-build --output $artifacts_dir $packageParam /nologo}
 
-	exec { dotnet pack $source_dir\AutoMapper.Collection.LinqToSQL -c $config --include-symbols --no-build --output $artifacts_dir --version-suffix="$suffix" /nologo}
+	exec { dotnet pack $source_dir\AutoMapper.Collection.LinqToSQL -c $config --include-symbols --no-build --output $artifacts_dir $packageParam /nologo}
 }
 
 task test {


### PR DESCRIPTION
This PR contains fixes for 2 issues
1. Myget is not handle symbol packages and will fail the build. Turning off the publish of symbols when building on master branch
2. `dotnet` version `2.1.0-preview1-006635` will throw error when empty `--version-suffix` parameters.

When this will be merged into `master` the build should succeed with new packages on myget feed. To build and publish to nuget.org, make a recreate the tag.

Change `origin` to your remote name
```
git checkout master
git pull origin
git tag -d v3.1.1
git push origin :refs/tags/v3.1.1
git tag v3.1.1
git push origin --tags
```

@jbogard @TylerCarlson1 