### PR TITLE
Add support for value types

### DIFF
--- a/src/AutoMapper.Collection/EquivalencyExpression/EquivalentExpression.cs
+++ b/src/AutoMapper.Collection/EquivalencyExpression/EquivalentExpression.cs
@@ -25,16 +25,14 @@ namespace AutoMapper.EquivalencyExpression
         }
     }
 
-    internal class EquivalentExpression<TSource,TDestination> : IEquivalentComparer<TSource, TDestination>
-        where TSource : class 
-        where TDestination : class
+    internal class EquivalentExpression<TSource, TDestination> : IEquivalentComparer<TSource, TDestination>
     {
         private readonly Expression<Func<TSource, TDestination, bool>> _equivalentExpression;
         private readonly Func<TSource, TDestination, bool> _equivalentFunc;
         private readonly Func<TSource, int> _sourceHashCodeFunc;
         private readonly Func<TDestination, int> _destinationHashCodeFunc;
 
-        public EquivalentExpression(Expression<Func<TSource,TDestination,bool>> equivalentExpression)
+        public EquivalentExpression(Expression<Func<TSource, TDestination, bool>> equivalentExpression)
         {
             _equivalentExpression = equivalentExpression;
             _equivalentFunc = _equivalentExpression.Compile();
@@ -43,22 +41,25 @@ namespace AutoMapper.EquivalencyExpression
             var destinationParameter = equivalentExpression.Parameters[1];
 
             var members = HashableExpressionsVisitor.Expand(sourceParameter, destinationParameter, equivalentExpression);
-            
+
             _sourceHashCodeFunc = members.Item1.GetHashCodeExpression<TSource>(sourceParameter).Compile();
             _destinationHashCodeFunc = members.Item2.GetHashCodeExpression<TDestination>(destinationParameter).Compile();
         }
 
         public bool IsEquivalent(object source, object destination)
         {
-            var src = source as TSource;
-            var dest = destination as TDestination;
 
-            if (src == null && dest == null)
+            if (source == null && destination == null)
             {
                 return true;
             }
 
-            if (src == null || dest == null)
+            if (source == null || destination == null)
+            {
+                return false;
+            }
+
+            if (!(source is TSource src) || !(destination is TDestination dest))
             {
                 return false;
             }
@@ -77,10 +78,10 @@ namespace AutoMapper.EquivalencyExpression
 
         public int GetHashCode(object obj)
         {
-            if (obj is TSource)
-                return _sourceHashCodeFunc(obj as TSource);
-            if (obj is TDestination)
-                return _destinationHashCodeFunc(obj as TDestination);
+            if (obj is TSource src)
+                return _sourceHashCodeFunc(src);
+            if (obj is TDestination dest)
+                return _destinationHashCodeFunc(dest);
             return default(int);
         }
     }

--- a/src/AutoMapper.Collection/EquivalencyExpression/EquivalentExpressions.cs
+++ b/src/AutoMapper.Collection/EquivalencyExpression/EquivalentExpressions.cs
@@ -94,8 +94,6 @@ namespace AutoMapper.EquivalencyExpression
         /// <param name="EquivalentExpression">Equivalent Expression between <typeparamref name="TSource"/> and <typeparamref name="TDestination"/></param>
         /// <returns></returns>
         public static IMappingExpression<TSource, TDestination> EqualityComparison<TSource, TDestination>(this IMappingExpression<TSource, TDestination> mappingExpression, Expression<Func<TSource, TDestination, bool>> EquivalentExpression)
-            where TSource : class
-            where TDestination : class
         {
             var typePair = new TypePair(typeof(TSource), typeof(TDestination));
             _equalityComparisonCache.AddOrUpdate(typePair,

--- a/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
+++ b/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
@@ -16,7 +16,7 @@ namespace AutoMapper.Mappers
 
         public static TDestination Map<TSource, TSourceItem, TDestination, TDestinationItem>(TSource source, TDestination destination, ResolutionContext context, IEquivalentComparer equivalentComparer)
             where TSource : IEnumerable<TSourceItem>
-            where TDestination : class, ICollection<TDestinationItem>
+            where TDestination : ICollection<TDestinationItem>
         {
             if (source == null || destination == null)
             {


### PR DESCRIPTION
Implements solution to Issue #98 

All current tests passed. Successfully tested in my application for my use case which required it, while the other collection mappings kept working as before.

Pattern matching code requires C# 7.0 (MSBuild v15.0+). If that's not acceptable, I can amend to change to classic C# syntax.