### PR TITLE
Avoid circular lookups with usage of FindTypeMapFor instead of ResolveTypeMap

### DIFF
--- a/src/AutoMapper.Collection.Tests/NotExistingTests.cs
+++ b/src/AutoMapper.Collection.Tests/NotExistingTests.cs
@@ -17,7 +17,7 @@ namespace AutoMapper.Collection
             });
             IMapper mapper = new Mapper(configuration);
 
-            var system = new System
+            var originalModel = new System
             {
                 Name = "My First System",
                 Contacts = new List<Contact>
@@ -36,10 +36,16 @@ namespace AutoMapper.Collection
                 }
             };
 
-            var model = mapper.Map<SystemViewModel>(system);
-            model.Name.Should().Be(system.Name);
-            model.Contacts.Single().Name.Should().Be(system.Contacts.Single().Name);
-            model.Contacts.Single().Emails.Single().Address.Should().Be(system.Contacts.Single().Emails.Single().Address);
+            var originalEmail = originalModel.Contacts.Single().Emails.Single();
+
+            var assertModel = mapper.Map<SystemViewModel>(originalModel);
+            assertModel.Name.Should().Be(originalModel.Name);
+            assertModel.Contacts.Single().Name.Should().Be(originalModel.Contacts.Single().Name);
+            assertModel.Contacts.Single().Emails.Single().Address.Should().Be(originalModel.Contacts.Single().Emails.Single().Address);
+
+            mapper.Map(assertModel, originalModel);
+            // This tests if equality was found and mapped to pre-existing object and not defaulting to AM and clearing and regenerating the list
+            originalModel.Contacts.Single().Emails.Single().Should().Be(originalEmail);
         }
 
         public class System

--- a/src/AutoMapper.Collection.Tests/NotExistingTests.cs
+++ b/src/AutoMapper.Collection.Tests/NotExistingTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using AutoMapper.EquivalencyExpression;
 using FluentAssertions;
 using Xunit;
@@ -12,7 +13,6 @@ namespace AutoMapper.Collection
         {
             var configuration = new MapperConfiguration(x =>
             {
-                //x.CreateMissingTypeMaps = false;
                 x.AddCollectionMappers();
             });
             IMapper mapper = new Mapper(configuration);
@@ -36,7 +36,10 @@ namespace AutoMapper.Collection
                 }
             };
 
-            mapper.Map<SystemViewModel>(system);
+            var model = mapper.Map<SystemViewModel>(system);
+            model.Name.Should().Be(system.Name);
+            model.Contacts.Single().Name.Should().Be(system.Contacts.Single().Name);
+            model.Contacts.Single().Emails.Single().Address.Should().Be(system.Contacts.Single().Emails.Single().Address);
         }
 
         public class System

--- a/src/AutoMapper.Collection.Tests/NotExistingTests.cs
+++ b/src/AutoMapper.Collection.Tests/NotExistingTests.cs
@@ -1,0 +1,99 @@
+﻿using System.Collections.Generic;
+using AutoMapper.EquivalencyExpression;
+using FluentAssertions;
+using Xunit;
+
+namespace AutoMapper.Collection
+{
+    public class NotExistingTests
+    {
+        [Fact]
+        public void Should_not_throw_exception_for_nonexisting_types()
+        {
+            var configuration = new MapperConfiguration(x =>
+            {
+                //x.CreateMissingTypeMaps = false;
+                x.AddCollectionMappers();
+            });
+            IMapper mapper = new Mapper(configuration);
+
+            var system = new System
+            {
+                Name = "My First System",
+                Contacts = new List<Contact>
+                {
+                    new Contact
+                    {
+                        Name = "John",
+                        Emails = new List<Email>()
+                        {
+                            new Email
+                            {
+                                 Address = "john@doe.com"
+                            }
+                        }
+                    }
+                }
+            };
+
+            mapper.Map<SystemViewModel>(system);
+        }
+
+        public class System
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public ICollection<Contact> Contacts { get; set; }
+        }
+
+        public class Contact
+        {
+            public int Id { get; set; }
+            public int SystemId { get; set; }
+            public string Name { get; set; }
+
+            public System System { get; set; }
+
+            public ICollection<Email> Emails { get; set; }
+        }
+
+        public class Email
+        {
+            public int Id { get; set; }
+
+            public int ContactId { get; set; }
+            public string Address { get; set; }
+
+            public Contact Contact { get; set; }
+        }
+
+        public class SystemViewModel
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public ICollection<ContactViewModel> Contacts { get; set; }
+        }
+
+        public class ContactViewModel
+        {
+            public int Id { get; set; }
+            public int SystemId { get; set; }
+            public string Name { get; set; }
+
+            public SystemViewModel System { get; set; }
+
+            public ICollection<EmailViewModel> Emails { get; set; }
+        }
+
+        public class EmailViewModel
+        {
+            public int Id { get; set; }
+            public int ContactId { get; set; }
+            public string Address { get; set; }
+
+            public ContactViewModel Contact { get; set; }
+        }
+    }
+}

--- a/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
+++ b/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
@@ -66,9 +66,16 @@ namespace AutoMapper.Mappers
 
         public bool IsMatch(TypePair typePair)
         {
-            return typePair.SourceType.IsEnumerableType()
-                   && typePair.DestinationType.IsCollectionType()
-                   && this.GetEquivalentExpression(TypeHelper.GetElementType(typePair.SourceType), TypeHelper.GetElementType(typePair.DestinationType)) != null;
+            if (typePair.SourceType.IsEnumerableType()
+                   && typePair.DestinationType.IsCollectionType())
+            {
+                var realType = new TypePair(TypeHelper.GetElementType(typePair.SourceType), TypeHelper.GetElementType(typePair.DestinationType));
+
+                return realType != typePair
+                    && this.GetEquivalentExpression(realType.SourceType, realType.DestinationType) != null;
+            }
+
+            return false;
         }
 
         public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap, IMemberMap memberMap,


### PR DESCRIPTION
This is a failing test for https://github.com/AutoMapper/AutoMapper.Collection.EFCore/issues/13