### PR TITLE
Avoid circular reference when mapping unmapped types

### DIFF
--- a/src/AutoMapper.Collection.EntityFramework.Tests/EntityFramworkUnmappedTypes.cs
+++ b/src/AutoMapper.Collection.EntityFramework.Tests/EntityFramworkUnmappedTypes.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity;
+using System.Data.SqlServerCe;
+using System.Linq;
+using AutoMapper.EntityFramework;
+using AutoMapper.EquivalencyExpression;
+using FluentAssertions;
+using Xunit;
+
+namespace AutoMapper.Collection.EntityFramework.Tests
+{
+    public class EntityFramworkUnmappedTypes
+    {
+        private void ConfigureMapper(IMapperConfigurationExpression cfg)
+        {
+            cfg.AddCollectionMappers();
+            cfg.SetGeneratePropertyMaps<GenerateEntityFrameworkPrimaryKeyPropertyMaps<DB>>();
+        }
+
+        protected IMapper CreateMapper(Action<IMapperConfigurationExpression> cfg)
+        {
+            var map = new MapperConfiguration(cfg);
+            map.CompileMappings();
+
+            var mapper = map.CreateMapper();
+            mapper.ConfigurationProvider.AssertConfigurationIsValid();
+            return mapper;
+        }
+
+
+        [Fact]
+        public void Should_not_throw_exception_for_nonexisting_types()
+        {
+            var mapper = CreateMapper(ConfigureMapper);
+
+            var originalModel = new System
+            {
+                Name = "My First System",
+                Contacts = new List<Contact>
+                {
+                    new Contact
+                    {
+                        Name = "John",
+                        Emails = new List<Email>()
+                        {
+                            new Email
+                            {
+                                 Address = "john@doe.com"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var originalEmail = originalModel.Contacts.Single().Emails.Single();
+
+            var assertModel = mapper.Map<SystemViewModel>(originalModel);
+            assertModel.Name.Should().Be(originalModel.Name);
+            assertModel.Contacts.Single().Name.Should().Be(originalModel.Contacts.Single().Name);
+            assertModel.Contacts.Single().Emails.Single().Address.Should().Be(originalModel.Contacts.Single().Emails.Single().Address);
+
+            assertModel.Contacts.Single().Emails.Add(new EmailViewModel { Address = "jane@doe.com" });
+
+            mapper.Map(assertModel, originalModel);
+            // This tests if equality was found and mapped to pre-existing object and not defaulting to AM and clearing and regenerating the list
+            originalModel.Contacts.Single().Emails.First().Should().Be(originalEmail);
+        }
+
+        public class DB : DbContext
+        {
+            public DB()
+                : base(new SqlCeConnection("Data Source=MyDatabase.sdf;Persist Security Info=False;"), contextOwnsConnection: true)
+            {
+            }
+
+            public DbSet<System> Systems { get; set; }
+            public DbSet<Contact> Contacts { get; set; }
+            public DbSet<Email> Emails { get; set; }
+        }
+
+
+        public class System
+        {
+            public Guid Id { get; set; } = Guid.NewGuid();
+            public string Name { get; set; }
+
+            public ICollection<Contact> Contacts { get; set; }
+        }
+
+        public class Contact
+        {
+            public Guid Id { get; set; } = Guid.NewGuid();
+            public Guid SystemId { get; set; }
+            public string Name { get; set; }
+
+            [ForeignKey("SystemId")]
+            public System System { get; set; }
+
+            public ICollection<Email> Emails { get; set; }
+        }
+
+        public class Email
+        {
+            public Guid Id { get; set; } = Guid.NewGuid();
+
+            public Guid ContactId { get; set; }
+            public string Address { get; set; }
+
+            [ForeignKey("ContactId")]
+            public Contact Contact { get; set; }
+        }
+
+        public class SystemViewModel
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+
+            public ICollection<ContactViewModel> Contacts { get; set; }
+        }
+
+        public class ContactViewModel
+        {
+            public Guid Id { get; set; }
+            public Guid SystemId { get; set; }
+            public string Name { get; set; }
+
+            public SystemViewModel System { get; set; }
+
+            public ICollection<EmailViewModel> Emails { get; set; }
+        }
+
+        public class EmailViewModel
+        {
+            public Guid Id { get; set; }
+            public Guid ContactId { get; set; }
+            public string Address { get; set; }
+
+            public ContactViewModel Contact { get; set; }
+        }
+    }
+}

--- a/src/AutoMapper.Collection.Tests/NotExistingTests.cs
+++ b/src/AutoMapper.Collection.Tests/NotExistingTests.cs
@@ -17,7 +17,7 @@ namespace AutoMapper.Collection
             });
             IMapper mapper = new Mapper(configuration);
 
-            var system = new System
+            var originalModel = new System
             {
                 Name = "My First System",
                 Contacts = new List<Contact>
@@ -36,10 +36,16 @@ namespace AutoMapper.Collection
                 }
             };
 
-            var model = mapper.Map<SystemViewModel>(system);
-            model.Name.Should().Be(system.Name);
-            model.Contacts.Single().Name.Should().Be(system.Contacts.Single().Name);
-            model.Contacts.Single().Emails.Single().Address.Should().Be(system.Contacts.Single().Emails.Single().Address);
+            var originalEmail = originalModel.Contacts.Single().Emails.Single();
+
+            var assertModel = mapper.Map<SystemViewModel>(originalModel);
+            assertModel.Name.Should().Be(originalModel.Name);
+            assertModel.Contacts.Single().Name.Should().Be(originalModel.Contacts.Single().Name);
+            assertModel.Contacts.Single().Emails.Single().Address.Should().Be(originalModel.Contacts.Single().Emails.Single().Address);
+
+            mapper.Map(assertModel, originalModel);
+            // This tests if equality was found and mapped to pre-existing object and not defaulting to AM and clearing and regenerating the list
+            originalModel.Contacts.Single().Emails.Single().Should().Be(originalEmail);
         }
 
         public class System

--- a/src/AutoMapper.Collection.Tests/NotExistingTests.cs
+++ b/src/AutoMapper.Collection.Tests/NotExistingTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using AutoMapper.EquivalencyExpression;
 using FluentAssertions;
 using Xunit;
@@ -12,7 +13,6 @@ namespace AutoMapper.Collection
         {
             var configuration = new MapperConfiguration(x =>
             {
-                //x.CreateMissingTypeMaps = false;
                 x.AddCollectionMappers();
             });
             IMapper mapper = new Mapper(configuration);
@@ -36,7 +36,10 @@ namespace AutoMapper.Collection
                 }
             };
 
-            mapper.Map<SystemViewModel>(system);
+            var model = mapper.Map<SystemViewModel>(system);
+            model.Name.Should().Be(system.Name);
+            model.Contacts.Single().Name.Should().Be(system.Contacts.Single().Name);
+            model.Contacts.Single().Emails.Single().Address.Should().Be(system.Contacts.Single().Emails.Single().Address);
         }
 
         public class System

--- a/src/AutoMapper.Collection.Tests/NotExistingTests.cs
+++ b/src/AutoMapper.Collection.Tests/NotExistingTests.cs
@@ -1,0 +1,99 @@
+﻿using System.Collections.Generic;
+using AutoMapper.EquivalencyExpression;
+using FluentAssertions;
+using Xunit;
+
+namespace AutoMapper.Collection
+{
+    public class NotExistingTests
+    {
+        [Fact]
+        public void Should_not_throw_exception_for_nonexisting_types()
+        {
+            var configuration = new MapperConfiguration(x =>
+            {
+                //x.CreateMissingTypeMaps = false;
+                x.AddCollectionMappers();
+            });
+            IMapper mapper = new Mapper(configuration);
+
+            var system = new System
+            {
+                Name = "My First System",
+                Contacts = new List<Contact>
+                {
+                    new Contact
+                    {
+                        Name = "John",
+                        Emails = new List<Email>()
+                        {
+                            new Email
+                            {
+                                 Address = "john@doe.com"
+                            }
+                        }
+                    }
+                }
+            };
+
+            mapper.Map<SystemViewModel>(system);
+        }
+
+        public class System
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public ICollection<Contact> Contacts { get; set; }
+        }
+
+        public class Contact
+        {
+            public int Id { get; set; }
+            public int SystemId { get; set; }
+            public string Name { get; set; }
+
+            public System System { get; set; }
+
+            public ICollection<Email> Emails { get; set; }
+        }
+
+        public class Email
+        {
+            public int Id { get; set; }
+
+            public int ContactId { get; set; }
+            public string Address { get; set; }
+
+            public Contact Contact { get; set; }
+        }
+
+        public class SystemViewModel
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public ICollection<ContactViewModel> Contacts { get; set; }
+        }
+
+        public class ContactViewModel
+        {
+            public int Id { get; set; }
+            public int SystemId { get; set; }
+            public string Name { get; set; }
+
+            public SystemViewModel System { get; set; }
+
+            public ICollection<EmailViewModel> Emails { get; set; }
+        }
+
+        public class EmailViewModel
+        {
+            public int Id { get; set; }
+            public int ContactId { get; set; }
+            public string Address { get; set; }
+
+            public ContactViewModel Contact { get; set; }
+        }
+    }
+}

--- a/src/AutoMapper.Collection.Tests/NotExistingTests.cs
+++ b/src/AutoMapper.Collection.Tests/NotExistingTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using AutoMapper.EquivalencyExpression;
 using FluentAssertions;
@@ -43,14 +44,14 @@ namespace AutoMapper.Collection
             assertModel.Contacts.Single().Name.Should().Be(originalModel.Contacts.Single().Name);
             assertModel.Contacts.Single().Emails.Single().Address.Should().Be(originalModel.Contacts.Single().Emails.Single().Address);
 
+            assertModel.Contacts.Single().Emails.Add(new EmailViewModel { Address = "jane@doe.com" });
+
             mapper.Map(assertModel, originalModel);
-            // This tests if equality was found and mapped to pre-existing object and not defaulting to AM and clearing and regenerating the list
-            originalModel.Contacts.Single().Emails.Single().Should().Be(originalEmail);
         }
 
         public class System
         {
-            public int Id { get; set; }
+            public Guid Id { get; set; } = Guid.NewGuid();
             public string Name { get; set; }
 
             public ICollection<Contact> Contacts { get; set; }
@@ -58,8 +59,8 @@ namespace AutoMapper.Collection
 
         public class Contact
         {
-            public int Id { get; set; }
-            public int SystemId { get; set; }
+            public Guid Id { get; set; } = Guid.NewGuid();
+            public Guid SystemId { get; set; }
             public string Name { get; set; }
 
             public System System { get; set; }
@@ -69,9 +70,9 @@ namespace AutoMapper.Collection
 
         public class Email
         {
-            public int Id { get; set; }
+            public Guid Id { get; set; } = Guid.NewGuid();
 
-            public int ContactId { get; set; }
+            public Guid ContactId { get; set; }
             public string Address { get; set; }
 
             public Contact Contact { get; set; }
@@ -79,7 +80,7 @@ namespace AutoMapper.Collection
 
         public class SystemViewModel
         {
-            public int Id { get; set; }
+            public Guid Id { get; set; }
             public string Name { get; set; }
 
             public ICollection<ContactViewModel> Contacts { get; set; }
@@ -87,8 +88,8 @@ namespace AutoMapper.Collection
 
         public class ContactViewModel
         {
-            public int Id { get; set; }
-            public int SystemId { get; set; }
+            public Guid Id { get; set; }
+            public Guid SystemId { get; set; }
             public string Name { get; set; }
 
             public SystemViewModel System { get; set; }
@@ -98,8 +99,8 @@ namespace AutoMapper.Collection
 
         public class EmailViewModel
         {
-            public int Id { get; set; }
-            public int ContactId { get; set; }
+            public Guid Id { get; set; }
+            public Guid ContactId { get; set; }
             public string Address { get; set; }
 
             public ContactViewModel Contact { get; set; }

--- a/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
+++ b/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
@@ -66,9 +66,16 @@ namespace AutoMapper.Mappers
 
         public bool IsMatch(TypePair typePair)
         {
-            return typePair.SourceType.IsEnumerableType()
-                   && typePair.DestinationType.IsCollectionType()
-                   && this.GetEquivalentExpression(TypeHelper.GetElementType(typePair.SourceType), TypeHelper.GetElementType(typePair.DestinationType)) != null;
+            if (typePair.SourceType.IsEnumerableType()
+                   && typePair.DestinationType.IsCollectionType())
+            {
+                var realType = new TypePair(TypeHelper.GetElementType(typePair.SourceType), TypeHelper.GetElementType(typePair.DestinationType));
+
+                return realType != typePair
+                    && this.GetEquivalentExpression(realType.SourceType, realType.DestinationType) != null;
+            }
+
+            return false;
         }
 
         public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap, IMemberMap memberMap,

--- a/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
+++ b/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
@@ -70,11 +70,6 @@ namespace AutoMapper.Mappers
                    && typePair.DestinationType.IsCollectionType();
         }
 
-        public TypePair GetAssociatedTypes(TypePair initialTypes)
-        {
-            return new TypePair(TypeHelper.GetElementType(initialTypes.SourceType), TypeHelper.GetElementType(initialTypes.DestinationType));
-        }
-
         public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap, IMemberMap memberMap,
             Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {

--- a/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
+++ b/src/AutoMapper.Collection/Mappers/EquivalentExpressionAddRemoveCollectionMapper.cs
@@ -62,7 +62,7 @@ namespace AutoMapper.Mappers
             return destination;
         }
 
-        private static readonly MethodInfo _mapMethodInfo = typeof(EquivalentExpressionAddRemoveCollectionMapper).GetRuntimeMethods().Single(_ => _.IsStatic && _.Name == nameof(Map));
+        private static readonly MethodInfo _mapMethodInfo = typeof(EquivalentExpressionAddRemoveCollectionMapper).GetRuntimeMethods().Single(x => x.IsStatic && x.Name == nameof(Map));
 
         public bool IsMatch(TypePair typePair)
         {


### PR DESCRIPTION
When using EF/EFCore and have an entity that have references to the parent (you should avoid it) the call to `ResolveTypeMap` will go into an circular lookup.

With this changes the logic to see if `IsMatch` is changed to only see if the source/dest is of collection types and in that case we try to create the expression to use. During creation of the expression we can call the `ResolveTypeMap` (without going into the circular lookup), and if we not get any equivalent mapping we find the next `IObjectMapper` that can handle the source/dest type and if no other is found we will fallback into the `CollectionMapper` (that was the only fallback mapper before this change).

https://github.com/AutoMapper/AutoMapper.Collection.EFCore/issues/13