### PR TITLE
Allow ordinal-based elements reuse

### DIFF
--- a/src/AutoMapper.Collection.Tests/MemberConfigurationExpressionExtensionsTests.cs
+++ b/src/AutoMapper.Collection.Tests/MemberConfigurationExpressionExtensionsTests.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace AutoMapper.Collection;
+
+public class MemberConfigurationExpressionExtensionsTests : MappingTestBase
+{
+    
+    [Fact]
+    public void MapWithOrdinalRecycling_ShouldWorkWithEmptySourceAndDestination()
+    {
+        var mapper = CreateMapper();
+        
+        var source = new SourceParent
+        {
+            Children = new List<SourceChild>()
+        };
+        
+        var destination = new DestinationParent
+        {
+            Children = new List<DestinationChild>()
+        };
+        
+        mapper.Map(source, destination);
+        Assert.Equal(0, destination.Children.Count);
+    }
+    
+    [Fact]
+    public void MapWithOrdinalRecycling_ShouldReuseExisting()
+    {
+        var mapper = CreateMapper();
+        
+        var source = new SourceParent
+        {
+            Children = new List<SourceChild>
+            {
+                new()
+                {
+                    Property = "Updated Name"
+                }
+            }
+        };
+        
+        var originalChild = new DestinationChild
+        {
+            Id = 1,
+            Property = "Original Name"
+        };
+        
+        var destination = new DestinationParent
+        {
+            Children = new List<DestinationChild>
+            {
+                originalChild
+            }
+        };
+        
+        mapper.Map(source, destination);
+        Assert.Equal(1, destination.Children.Count);
+        Assert.Equal(1, destination.Children[0].Id);
+        Assert.Equal("Updated Name", destination.Children[0].Property);
+        Assert.True(ReferenceEquals(originalChild, destination.Children[0]));
+    }
+    
+    [Fact]
+    public void MapWithOrdinalRecycling_ShouldAddLast()
+    {
+        var mapper = CreateMapper();
+        
+        var source = new SourceParent
+        {
+            Children = new List<SourceChild>
+            {
+                new()
+                {
+                    Property = "Item 1 Name"
+                },
+                new ()
+                {
+                    Property = "Item 2 Name"
+                }
+            }
+        };
+        
+        var originalChild = new DestinationChild
+        {
+            Id = 1,
+            Property = "Item 1 Name"
+        };
+        
+        var destination = new DestinationParent
+        {
+            Children = new List<DestinationChild>
+            {
+                originalChild
+            }
+        };
+        
+        mapper.Map(source, destination);
+        Assert.Equal(2, destination.Children.Count);
+        Assert.Equal(1, destination.Children[0].Id);
+        Assert.Equal("Item 1 Name", destination.Children[0].Property);
+        Assert.True(ReferenceEquals(originalChild, destination.Children[0]));
+        Assert.Equal("Item 2 Name", destination.Children[1].Property);
+    }
+    
+    [Fact]
+    public void MapWithOrdinalRecycling_ShouldRemoveLast()
+    {
+        var mapper = CreateMapper();
+        
+        var source = new SourceParent
+        {
+            Children = new List<SourceChild>
+            {
+                new()
+                {
+                    Property = "Item 1 Name"
+                }
+            }
+        };
+        
+        var originalChild = new DestinationChild
+        {
+            Id = 1,
+            Property = "Item 1 Name"
+        };
+        
+        var destination = new DestinationParent
+        {
+            Children = new List<DestinationChild>
+            {
+                originalChild,
+                new ()
+                {
+                    Id = 2,
+                    Property = "Item 2 Name"
+                }
+            }
+        };
+        
+        mapper.Map(source, destination);
+        Assert.Equal(1, destination.Children.Count);
+        Assert.Equal(1, destination.Children[0].Id);
+        Assert.Equal("Item 1 Name", destination.Children[0].Property);
+        Assert.True(ReferenceEquals(originalChild, destination.Children[0]));
+    }
+
+    private IMapper CreateMapper()
+    {
+        return CreateMapper(cfg =>
+        {
+            cfg.CreateMap<SourceParent, DestinationParent>()
+                .ForMember(
+                    d => d.Children,
+                    opt =>
+                        opt.MapWithOrdinalRecycling<SourceParent, SourceChild, DestinationParent, DestinationChild>(s =>
+                            s.Children));
+            cfg
+                .CreateMap<SourceChild, DestinationChild>()
+                .ForMember(o => o.Id, mo => mo.Ignore());
+        });
+    }
+    
+    private class SourceParent
+    {
+        public List<SourceChild> Children { get; set; } = new();
+    }
+    
+    private class SourceChild
+    {
+        public string Property { get; init; }
+    }
+    
+    private class DestinationParent
+    {
+        public IList<DestinationChild> Children { get; set; } = new List<DestinationChild>();
+    }
+    
+    private class DestinationChild
+    {
+        public int Id { get; set; }
+        public string Property { get; set; }
+    }
+}

--- a/src/AutoMapper.Collection/MemberConfigurationExpressionExtensions.cs
+++ b/src/AutoMapper.Collection/MemberConfigurationExpressionExtensions.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AutoMapper.Collection;
+
+public static class MemberConfigurationExpressionExtensions
+{
+    /// <summary>
+    /// Maps children collection from source to destination with recycling of existing destination objects.
+    /// </summary>
+    /// <param name="expression">Member configuration expression</param>
+    /// <param name="sourceMemberGetter">Function retrieving destination collection from destination object</param>
+    /// <typeparam name="TSource">Type of source object</typeparam>
+    /// <typeparam name="TSourceChild">Type of source object&apos;s child</typeparam>
+    /// <typeparam name="TDestination">Type of destination object</typeparam>
+    /// <typeparam name="TDestProp">Type of destination object</typeparam>
+    /// <typeparam name="TDestChild">Type of destination object&apos;s child</typeparam>
+    public static void MapWithOrdinalRecycling<TSource, TSourceChild, TDestination, TDestProp, TDestChild>(
+        this IMemberConfigurationExpression<TSource, TDestination, IList<TDestChild>> expression,
+        Func<TSource, IList<TSourceChild>> sourceMemberGetter)
+        where TDestProp : IList<TDestChild>
+    {
+        expression.MapFrom((src, _, destinationList, ctx) =>
+        {
+            var mapper = ctx.Mapper;
+            var source = sourceMemberGetter(src);
+            
+            var itemsToRecycle = Math.Min(destinationList.Count, source.Count);
+            
+            var destinationToKeep = destinationList
+                .Take(itemsToRecycle)
+                .Select((dstChild, i) => mapper.Map(source[i], dstChild));
+            var destinationToAdd = source
+                .Skip(itemsToRecycle)
+                .Select(o => mapper.Map<TDestChild>(o))
+                .ToList();
+            return destinationToKeep.Concat(destinationToAdd).ToList();
+        });
+    }
+
+    /// <summary>
+    /// Maps children collection from source to destination with recycling of existing destination objects.
+    /// </summary>
+    /// <param name="expression">Member configuration expression</param>
+    /// <param name="sourceMemberGetter">Function retrieving destination collection from destination object</param>
+    /// <typeparam name="TSource">Type of source object</typeparam>
+    /// <typeparam name="TSourceChild">Type of source object&apos;s child</typeparam>
+    /// <typeparam name="TDestination">Type of destination object</typeparam>
+    /// <typeparam name="TDestChild">Type of destination object&apos;s child</typeparam>
+    public static void MapWithOrdinalRecycling<TSource, TSourceChild, TDestination, TDestChild>(
+        this IMemberConfigurationExpression<TSource, TDestination, IList<TDestChild>> expression,
+        Func<TSource, IList<TSourceChild>> sourceMemberGetter)
+    {
+        MapWithOrdinalRecycling<TSource, TSourceChild, TDestination, IList<TDestChild>, TDestChild>(expression, sourceMemberGetter);
+    }
+}


### PR DESCRIPTION
This change allow re-use existing elements in target list when destination primary key is not exposed by DTO.
Method relies on index in the list instead so:
* when data is not modified delete and insert queries are not executed.
* when data is modified only update statement is performed
* when element is append to collection insert query is performed only for last item
* when element is removed from collection last element, delete is performed for last item from collection and update are performed for all items that were placed after removed
* when element is inserted into list at position n, insert is performed for last element, update is performed for elements from n to oldList.Length -1

It is not as efficient as primary-key based solution but, still improves performance when key-based solution is not feasible.

There are 2 overrides of the method:
* First allow property to be any type implementing IList<T> but, type inference does not work with it
* Second restricts property to be of type IList<T> (exactly) but, type inference works with it.
