### PR TITLE
Update ExpressionMapping package to latest version 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-2022
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Build and Test
@@ -27,7 +27,7 @@ jobs:
       run: ./Push.ps1
       shell: pwsh
     - name: Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: artifacts
         path: artifacts/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-2022
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Build and Test
@@ -30,7 +30,7 @@ jobs:
       run: ./Push.ps1
       shell: pwsh
     - name: Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: artifacts
         path: artifacts/**/* 

--- a/src/AutoMapper.Collection.EntityFramework.Tests/AutoMapper.Collection.EntityFramework.Tests.csproj
+++ b/src/AutoMapper.Collection.EntityFramework.Tests/AutoMapper.Collection.EntityFramework.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyName>AutoMapper.Collection.EntityFramework.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
+++ b/src/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
@@ -1,39 +1,39 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Description>Collection updating support for EntityFramework with AutoMapper. Extends DBSet&lt;T&gt; with Persist&lt;TDto&gt;().InsertUpdate(dto) and Persist&lt;TDto&gt;().Delete(dto).  Will find the matching object and will Insert/Update/Delete.</Description>
-    <Authors>Tyler Carlson</Authors>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <AssemblyName>AutoMapper.Collection.EntityFramework</AssemblyName>
-    <PackageId>AutoMapper.Collection.EntityFramework</PackageId>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/AutoMapper/Automapper.Collection</PackageProjectUrl>
-    <AssemblyOriginatorKeyFile>../Key.snk</AssemblyOriginatorKeyFile>
-    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <SignAssembly>true</SignAssembly>
-    <IncludeSymbols>true</IncludeSymbols>
-    <MinVerTagPrefix>v</MinVerTagPrefix>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
+	<PropertyGroup>
+		<Description>Collection updating support for EntityFramework with AutoMapper. Extends DBSet&lt;T&gt; with Persist&lt;TDto&gt;().InsertUpdate(dto) and Persist&lt;TDto&gt;().Delete(dto).  Will find the matching object and will Insert/Update/Delete.</Description>
+		<Authors>Tyler Carlson</Authors>
+		<TargetFrameworks>net8.0</TargetFrameworks>
+		<AssemblyName>AutoMapper.Collection.EntityFramework</AssemblyName>
+		<PackageId>AutoMapper.Collection.EntityFramework</PackageId>
+		<PackageIcon>icon.png</PackageIcon>
+		<PackageProjectUrl>https://github.com/AutoMapper/Automapper.Collection</PackageProjectUrl>
+		<AssemblyOriginatorKeyFile>../Key.snk</AssemblyOriginatorKeyFile>
+		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<SignAssembly>true</SignAssembly>
+		<IncludeSymbols>true</IncludeSymbols>
+		<MinVerTagPrefix>v</MinVerTagPrefix>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<Deterministic>true</Deterministic>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\..\icon.png" Pack="true" PackagePath="" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\icon.png" Pack="true" PackagePath="" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\AutoMapper.Collection\AutoMapper.Collection.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\AutoMapper.Collection\AutoMapper.Collection.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="1.0.0" />
-    <PackageReference Include="EntityFramework" Version="6.3.0" />
-    <PackageReference Include="MinVer" Version="2.3.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="8.0.0" />
+		<PackageReference Include="EntityFramework" Version="6.3.0" />
+		<PackageReference Include="MinVer" Version="2.3.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
 </Project>

--- a/src/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
+++ b/src/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
@@ -1,39 +1,39 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<Description>Collection updating support for EntityFramework with AutoMapper. Extends DBSet&lt;T&gt; with Persist&lt;TDto&gt;().InsertUpdate(dto) and Persist&lt;TDto&gt;().Delete(dto).  Will find the matching object and will Insert/Update/Delete.</Description>
-		<Authors>Tyler Carlson</Authors>
-		<TargetFrameworks>net8.0</TargetFrameworks>
-		<AssemblyName>AutoMapper.Collection.EntityFramework</AssemblyName>
-		<PackageId>AutoMapper.Collection.EntityFramework</PackageId>
-		<PackageIcon>icon.png</PackageIcon>
-		<PackageProjectUrl>https://github.com/AutoMapper/Automapper.Collection</PackageProjectUrl>
-		<AssemblyOriginatorKeyFile>../Key.snk</AssemblyOriginatorKeyFile>
-		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<SignAssembly>true</SignAssembly>
-		<IncludeSymbols>true</IncludeSymbols>
-		<MinVerTagPrefix>v</MinVerTagPrefix>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<EmbedUntrackedSources>true</EmbedUntrackedSources>
-		<Deterministic>true</Deterministic>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<None Include="..\..\icon.png" Pack="true" PackagePath="" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\AutoMapper.Collection\AutoMapper.Collection.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="8.0.0" />
-		<PackageReference Include="EntityFramework" Version="6.3.0" />
-		<PackageReference Include="MinVer" Version="2.3.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <PropertyGroup>
+    <Description>Collection updating support for EntityFramework with AutoMapper. Extends DBSet&lt;T&gt; with Persist&lt;TDto&gt;().InsertUpdate(dto) and Persist&lt;TDto&gt;().Delete(dto).  Will find the matching object and will Insert/Update/Delete.</Description>
+    <Authors>Tyler Carlson</Authors>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <AssemblyName>AutoMapper.Collection.EntityFramework</AssemblyName>
+    <PackageId>AutoMapper.Collection.EntityFramework</PackageId>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageProjectUrl>https://github.com/AutoMapper/Automapper.Collection</PackageProjectUrl>
+    <AssemblyOriginatorKeyFile>../Key.snk</AssemblyOriginatorKeyFile>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <SignAssembly>true</SignAssembly>
+    <IncludeSymbols>true</IncludeSymbols>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <None Include="..\..\icon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\AutoMapper.Collection\AutoMapper.Collection.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="8.0.0" />
+    <PackageReference Include="EntityFramework" Version="6.3.0" />
+    <PackageReference Include="MinVer" Version="2.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/src/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
+++ b/src/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
@@ -18,17 +18,17 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <None Include="..\..\icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\AutoMapper.Collection\AutoMapper.Collection.csproj" />
   </ItemGroup>
-
+  
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="1.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="8.0.0" />
     <PackageReference Include="EntityFramework" Version="6.3.0" />
     <PackageReference Include="MinVer" Version="2.3.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
+++ b/src/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Collection updating support for EntityFramework with AutoMapper. Extends DBSet&lt;T&gt; with Persist&lt;TDto&gt;().InsertUpdate(dto) and Persist&lt;TDto&gt;().Delete(dto).  Will find the matching object and will Insert/Update/Delete.</Description>
     <Authors>Tyler Carlson</Authors>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyName>AutoMapper.Collection.EntityFramework</AssemblyName>
     <PackageId>AutoMapper.Collection.EntityFramework</PackageId>
     <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapper.Collection.Tests/AutoMapper.Collection.Tests.csproj
+++ b/src/AutoMapper.Collection.Tests/AutoMapper.Collection.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyName>AutoMapper.Collection.Tests</AssemblyName>
     <RootNamespace>AutoMapper.Collection</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/src/AutoMapper.Collection/AutoMapper.Collection.csproj
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Collection Add/Remove/Update support for AutoMapper. AutoMapper.Collection adds EqualityComparison Expressions for TypeMaps to determine if Source and Destination type are equivalent to each other when mapping collections.</Description>
     <Authors>Tyler Carlson</Authors>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyName>AutoMapper.Collection</AssemblyName>
     <PackageId>AutoMapper.Collection</PackageId>
     <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapper.Collection/AutoMapper.Collection.csproj
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.csproj
@@ -1,34 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Description>Collection Add/Remove/Update support for AutoMapper. AutoMapper.Collection adds EqualityComparison Expressions for TypeMaps to determine if Source and Destination type are equivalent to each other when mapping collections.</Description>
-    <Authors>Tyler Carlson</Authors>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <AssemblyName>AutoMapper.Collection</AssemblyName>
-    <PackageId>AutoMapper.Collection</PackageId>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/AutoMapper/Automapper.Collection</PackageProjectUrl>
-    <AssemblyOriginatorKeyFile>../Key.snk</AssemblyOriginatorKeyFile>
-    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <SignAssembly>true</SignAssembly>
-    <IncludeSymbols>true</IncludeSymbols>
-    <MinVerTagPrefix>v</MinVerTagPrefix>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
+	<PropertyGroup>
+		<Description>Collection Add/Remove/Update support for AutoMapper. AutoMapper.Collection adds EqualityComparison Expressions for TypeMaps to determine if Source and Destination type are equivalent to each other when mapping collections.</Description>
+		<Authors>Tyler Carlson</Authors>
+		<TargetFrameworks>net8.0</TargetFrameworks>
+		<AssemblyName>AutoMapper.Collection</AssemblyName>
+		<PackageId>AutoMapper.Collection</PackageId>
+		<PackageIcon>icon.png</PackageIcon>
+		<PackageProjectUrl>https://github.com/AutoMapper/Automapper.Collection</PackageProjectUrl>
+		<AssemblyOriginatorKeyFile>../Key.snk</AssemblyOriginatorKeyFile>
+		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<SignAssembly>true</SignAssembly>
+		<IncludeSymbols>true</IncludeSymbols>
+		<MinVerTagPrefix>v</MinVerTagPrefix>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<Deterministic>true</Deterministic>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\..\icon.png" Pack="true" PackagePath="" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\icon.png" Pack="true" PackagePath="" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="[13.0.0, 14.0.0)" />
-    <PackageReference Include="MinVer" Version="2.3.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="AutoMapper" Version="[14.0.0, 15.0.0)" />
+		<PackageReference Include="MinVer" Version="2.3.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
 </Project>

--- a/src/AutoMapper.Collection/AutoMapper.Collection.csproj
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.csproj
@@ -1,34 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<Description>Collection Add/Remove/Update support for AutoMapper. AutoMapper.Collection adds EqualityComparison Expressions for TypeMaps to determine if Source and Destination type are equivalent to each other when mapping collections.</Description>
-		<Authors>Tyler Carlson</Authors>
-		<TargetFrameworks>net8.0</TargetFrameworks>
-		<AssemblyName>AutoMapper.Collection</AssemblyName>
-		<PackageId>AutoMapper.Collection</PackageId>
-		<PackageIcon>icon.png</PackageIcon>
-		<PackageProjectUrl>https://github.com/AutoMapper/Automapper.Collection</PackageProjectUrl>
-		<AssemblyOriginatorKeyFile>../Key.snk</AssemblyOriginatorKeyFile>
-		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<SignAssembly>true</SignAssembly>
-		<IncludeSymbols>true</IncludeSymbols>
-		<MinVerTagPrefix>v</MinVerTagPrefix>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<EmbedUntrackedSources>true</EmbedUntrackedSources>
-		<Deterministic>true</Deterministic>
-	</PropertyGroup>
+  <PropertyGroup>
+    <Description>Collection Add/Remove/Update support for AutoMapper. AutoMapper.Collection adds EqualityComparison Expressions for TypeMaps to determine if Source and Destination type are equivalent to each other when mapping collections.</Description>
+    <Authors>Tyler Carlson</Authors>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <AssemblyName>AutoMapper.Collection</AssemblyName>
+    <PackageId>AutoMapper.Collection</PackageId>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageProjectUrl>https://github.com/AutoMapper/Automapper.Collection</PackageProjectUrl>
+    <AssemblyOriginatorKeyFile>../Key.snk</AssemblyOriginatorKeyFile>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <SignAssembly>true</SignAssembly>
+    <IncludeSymbols>true</IncludeSymbols>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<None Include="..\..\icon.png" Pack="true" PackagePath="" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\icon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="AutoMapper" Version="[14.0.0, 15.0.0)" />
-		<PackageReference Include="MinVer" Version="2.3.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="[14.0.0, 15.0.0)" />
+    <PackageReference Include="MinVer" Version="2.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
to continue with https://github.com/AutoMapper/AutoMapper.Collection/pull/190
this project `AutoMapper.Collection.EntityFramework` was using `.net 6` and `AutoMapper.Extensions.ExpressionMapping 1.0.0` which has been updated to `8` and `8.0.0` but i think this wrong the project target EntityFramework which primarily used with dot net framework which as far as i know the `.net 6 or 8` the project Target Framework work with